### PR TITLE
chore: add comments on repo-a/bar.py

### DIFF
--- a/repo-a/bar.py
+++ b/repo-a/bar.py
@@ -1,2 +1,2 @@
-# Zen
+# Zen of Python
 import this


### PR DESCRIPTION
This PR updates only the docs/foo.md

Based on [our path-filtering mapping](https://github.com/kelvintaywl-cci/dynamic-config-showcase/blob/86d80c3ff232b060693cece02e7afbf0414bc41b/.circleci/config.yml#L14-L16), this should trigger the repo-a workflow only:

https://app.circleci.com/pipelines/github/kelvintaywl-cci/dynamic-config-showcase/20/workflows/6f2c1e77-8f63-4fc4-a6b0-d6873f0b01f4

In this case, [the required "done" job in the repo-a workflow only succeeded](https://app.circleci.com/pipelines/github/kelvintaywl-cci/dynamic-config-showcase/20/workflows/6f2c1e77-8f63-4fc4-a6b0-d6873f0b01f4/jobs/48).


And we can merge this PR:

<img width="694" alt="Screen Shot 2022-08-23 at 17 33 14" src="https://user-images.githubusercontent.com/2164346/186111846-1ba5b532-796e-468e-8fd4-b24c78139baa.png">
