### PR TITLE
chore: update repo-c/hoge.py

### DIFF
--- a/repo-c/hoge.py
+++ b/repo-c/hoge.py
@@ -1,1 +1,2 @@
-print("repo-c")
+if __name__ == "__main__":
+    print("repo-c")


### PR DESCRIPTION
This PR updates the repo-c/hoge.py

https://github.com/kelvintaywl-cci/dynamic-config-showcase/blob/cb0b6e35ec4e72013a0f6bb53d2a1c86736c92a5/.circleci/config.yml#L14-L20

Based on our path-filtering mapping above, this should:

- run all workflows for repo-a, repo-b, and repo-c, _but_
- exit early for all jobs unless it is relevant for repo-c

In this case, we can confirm indeed that:

- repo_a workflow:
  - [x] [test_repo_a job exited early](https://app.circleci.com/pipelines/github/kelvintaywl-cci/dynamic-config-showcase/41/workflows/748a9673-066e-48ad-8c63-0d6912cc6e79/jobs/127)
- repo_b workflow:
  - [x] [test_repo_b job exited early](https://app.circleci.com/pipelines/github/kelvintaywl-cci/dynamic-config-showcase/41/workflows/f4108594-659d-4ced-8e96-3cd05aa64b35/jobs/128)
  - [x] [deploy_repo_b job exited early](https://app.circleci.com/pipelines/github/kelvintaywl-cci/dynamic-config-showcase/41/workflows/f4108594-659d-4ced-8e96-3cd05aa64b35/jobs/130)
- repo_c workflow:
  - [x] [test_repo_c job continued, as expected](https://app.circleci.com/pipelines/github/kelvintaywl-cci/dynamic-config-showcase/41/workflows/f6e02b6d-206e-4b57-bc22-5d2fe49ce0e3/jobs/129)
  - [x] [deploy_repo_c job continued, as expected](https://app.circleci.com/pipelines/github/kelvintaywl-cci/dynamic-config-showcase/41/workflows/f6e02b6d-206e-4b57-bc22-5d2fe49ce0e3/jobs/131)

And we can merge this PR because all 5 required jobs are ✅ 

<img width="685" alt="Screen Shot 2022-08-27 at 9 18 29" src="https://user-images.githubusercontent.com/2164346/187006263-615e7348-e2fe-4204-8674-f2fd9d8d7967.png">
